### PR TITLE
[baxter_sim_io] Fix dependency because libqt5-dev does not exist

### DIFF
--- a/baxter_sim_io/package.xml
+++ b/baxter_sim_io/package.xml
@@ -13,11 +13,11 @@
   <buildtool_depend>catkin</buildtool_depend>
   <!--build_depend>qt_build</build_depend-->
   <build_depend>roscpp</build_depend>
-  <build_depend>libqt5-dev</build_depend>
+  <build_depend>qtbase5-dev</build_depend>
   <build_depend>baxter_core_msgs</build_depend>
   <!--run_depend>qt_build</run_depend-->
   <run_depend>roscpp</run_depend>
-  <run_depend>libqt5-dev</run_depend>
+  <run_depend>qtbase5-dev</run_depend>
   <run_depend>baxter_core_msgs</run_depend>
  
 </package>


### PR DESCRIPTION
See https://askubuntu.com/questions/508503/whats-the-development-package-for-qt5-in-14-04